### PR TITLE
Add VX-P820 Confirm Compatible

### DIFF
--- a/doc/RADIO_COMPATIBILITY.md
+++ b/doc/RADIO_COMPATIBILITY.md
@@ -66,6 +66,10 @@ Thales/Racal:
 * Liberty/PRC7332 Portable
 * 25/PRC6894 Portable
 
+Vertex Standard:
+
+* VX-P820
+
 Aeroflex/IFR:
 
 * 2975 Radio Test Set

--- a/doc/RADIO_COMPATIBILITY.md
+++ b/doc/RADIO_COMPATIBILITY.md
@@ -68,7 +68,7 @@ Thales/Racal:
 
 Vertex Standard:
 
-* VX-P820
+* VX-P820 Portable
 
 Aeroflex/IFR:
 


### PR DESCRIPTION
Add Vertex Standard VX-P820 series portables to the list of confirmed compatible radios.